### PR TITLE
Chapter 7: Interface and entity definitions

### DIFF
--- a/monolith/schema.graphql
+++ b/monolith/schema.graphql
@@ -79,32 +79,18 @@ interface MutationResponse {
 "Represents an Airlock user's common properties"
 interface User {
   id: ID!
-  "The user's first and last name"
-  name: String!
-  "The user's profile photo URL"
-  profilePicture: String!
 }
 
 "A host is a type of Airlock user. They own listings."
-type Host implements User {
+type Host implements User @key(fields: "id") {
   id: ID!
-  "The user's first and last name"
-  name: String!
-  "The user's profile photo URL"
-  profilePicture: String!
-  "The host's profile bio description, will be shown in the listing"
-  profileDescription: String!
   "The overall calculated rating for the host"
   overallRating: Float
 }
 
 "A guest is a type of Airlock user. They book places to stay."
-type Guest implements User {
+type Guest implements User @key(fields: "id") {
   id: ID!
-  "The user's first and last name"
-  name: String!
-  "The user's profile photo URL"
-  profilePicture: String!
   "Amount of money in the guest's wallet"
   funds: Float!
 }

--- a/subgraph-accounts/schema.graphql
+++ b/subgraph-accounts/schema.graphql
@@ -1,7 +1,35 @@
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key"])
-        
+  @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
 type Query {
   example: String
+}
+
+"Represents an Airlock user's common properties"
+interface User {
+  id: ID!
+  "The user's first and last name"
+  name: String!
+  "The user's profile photo URL"
+  profilePicture: String!
+}
+
+"A host is a type of Airlock user. They own listings."
+type Host implements User @key(fields: "id") {
+  id: ID!
+  "The user's first and last name"
+  name: String!
+  "The user's profile photo URL"
+  profilePicture: String!
+  "The host's profile bio description, will be shown in the listing"
+  profileDescrioption: String!
+}
+
+"A guest is a type of Airlock user. They book places to stay."
+type Guest implements User @key(fields: "id") {
+  id: ID!
+  "The user's first and last name"
+  name: String!
+  "The user's profile photo URL"
+  profilePicture: String!
 }


### PR DESCRIPTION
Chapter 7: [Interface and Entity definitions](https://www.apollographql.com/tutorials/voyage-part2/07-interface-and-entity-definitions)

Changes: 
- Add `User` interface to `subgraph-account`
- Add `Host` type to `subgraph-account` and convert it to an entity with the `@key` decorator
- Add `Guest` type to `subgraph-account` and convert it to an entity with the `@key` decorator
- Remove fields for `User`, `Host` and `Guest` that will be managed by the `subgraph-account` and will be resolved by the `monolith` at the moment.